### PR TITLE
Polymer2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-bower_components
+bower_components/
+bower_components-1.x/
 node_modules/
+bower-1.x.json

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ bower install d2l-demo-template --save-dev
 </head>
 <body>
 	<d2l-demo-template title="my-fixture-title">
-		<div class="d2l-demo-actions">
+		<div slot="d2l-demo-actions">
 			<!-- your actions -->
 		</div>
-		<div class="d2l-demo-fixture">
+		<div slot="d2l-demo-fixture">
 			<!-- your fixture -->
 		</div>
 	</d2l-demo-template>

--- a/bower.json
+++ b/bower.json
@@ -12,15 +12,15 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0",
-    "d2l-colors": "mdgbayly/colors#polymer2",
-    "d2l-typography": "mdgbayly/typography#polymer2"
+    "d2l-colors": "^2.2.3",
+    "d2l-typography": "^5.3.0"
   },
   "variants": {
     "1.x": {
       "dependencies": {
         "polymer": "Polymer/polymer#^1.7.0",
-        "d2l-colors": "mdgbayly/colors#polymer2",
-        "d2l-typography": "mdgbayly/typography#polymer2"
+        "d2l-colors": "^2.2.3",
+        "d2l-typography": "^5.3.0"
       }
     }
   }

--- a/bower.json
+++ b/bower.json
@@ -18,10 +18,13 @@
   "variants": {
     "1.x": {
       "dependencies": {
-        "polymer": "Polymer/polymer#^1.7.0",
+        "polymer": "Polymer/polymer#^1.9.1",
         "d2l-colors": "^2.2.3",
         "d2l-typography": "^5.3.0"
       }
     }
+  },
+  "resolutions": {
+    "webcomponentsjs": "^v1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,17 @@
     "package.json"
   ],
   "dependencies": {
-    "d2l-colors": "^2.2.3",
-    "d2l-typography": "^5.3.0",
-    "polymer": "^1.7.0"
+    "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0",
+    "d2l-colors": "mdgbayly/colors#polymer2",
+    "d2l-typography": "mdgbayly/typography#polymer2"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.7.0",
+        "d2l-colors": "mdgbayly/colors#polymer2",
+        "d2l-typography": "mdgbayly/typography#polymer2"
+      }
+    }
   }
 }

--- a/d2l-demo-template.html
+++ b/d2l-demo-template.html
@@ -241,15 +241,16 @@
 
 			_updateShadowState: function() {
 				var useShadow = this.$$('.d2l-demo-use-shadow');
-				 if (this._hasNativeShadowDOM()) {
+				var href;
+				if (this._hasNativeShadowDOM()) {
 					if (Polymer.Settings.useShadow) {
 						useShadow.textContent = 'Use Shady';
-						var href = this._removeQueryStringParameter(window.location.href, 'dom');
+						href = this._removeQueryStringParameter(window.location.href, 'dom');
 						href = this._updateQueryStringParameter(href, 'wc-shadydom');
 						useShadow.setAttribute('href', href);
 					} else {
 						useShadow.textContent = 'Use Shadow';
-						var href = this._updateQueryStringParameter(window.location.href, 'dom', 'shadow');
+						href = this._updateQueryStringParameter(window.location.href, 'dom', 'shadow');
 						href = this._removeQueryStringParameter(href, 'wc-shadydom');
 						useShadow.setAttribute('href', href);
 
@@ -261,16 +262,16 @@
 
 			_updateNativeCSSPropsState: function() {
 				var useNativeCSSProps = this.$$('.d2l-demo-use-native-css-props');
-
+				var href;
 				if (this._hasNativeCSSProps()) {
 					if (Polymer.Settings.useNativeCSSProperties) {
 						useNativeCSSProps.textContent = 'Use CSS Props Shim';
-						var href = this._removeQueryStringParameter(window.location.href, 'useNativeCSSProperties')
-						href = this._updateQueryStringParameter(href, 'wc-shimcssproperties')
+						href = this._removeQueryStringParameter(window.location.href, 'useNativeCSSProperties');
+						href = this._updateQueryStringParameter(href, 'wc-shimcssproperties');
 						useNativeCSSProps.setAttribute('href', href);
 					} else {
 						useNativeCSSProps.textContent = 'Use Native CSS Props';
-						var href = this._updateQueryStringParameter(window.location.href, 'useNativeCSSProperties', 'true');
+						href = this._updateQueryStringParameter(window.location.href, 'useNativeCSSProperties', 'true');
 						href = this._removeQueryStringParameter(href, 'wc-shimcssproperties');
 						useNativeCSSProps.setAttribute('href', href);
 					}
@@ -313,7 +314,7 @@
 			},
 
 			_hasNativeShadowDOM: function() {
-				return Polymer.Settings.nativeShadow || document.head.createShadowRoot || document.head.attachShadow;
+				return Polymer.Settings.nativeShadow || document.head.createShadowRoot;
 			},
 
 			_hasNativeCSSProps: function() {

--- a/d2l-demo-template.html
+++ b/d2l-demo-template.html
@@ -10,8 +10,8 @@
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
-<link rel="import" href="../d2l-typography/d2l-typography.html">
-<link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
+<!-- <link rel="import" href="../d2l-typography/d2l-typography.html">
+<link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html"> -->
 
 <script>
 (function() {
@@ -24,11 +24,13 @@
 
 		document.body.classList.add('d2l-typography');
 
+		var customStyle = document.createElement('custom-style');
 		var rootStyle = document.createElement('style', 'custom-style');
 		rootStyle.setAttribute('id', 'd2l-demo-template-root-style');
 		rootStyle.setAttribute('include', 'd2l-typography');
 		rootStyle.appendChild(document.createTextNode('html { font-size: 20px; font-weight: 300; }'));
-		document.head.appendChild(rootStyle);
+		customStyle.appendChild(rootStyle);
+		document.head.appendChild(customStyle);
 
 	};
 
@@ -85,7 +87,7 @@
 			:host .d2l-demo-template-actions {
 				margin-bottom: 0.7rem;
 			}
-			:host .d2l-demo-template-actions ::content button {
+			:host .d2l-demo-template-actions ::slotted(button) {
 				background-color: var(--d2l-color-woolonardo);
 				border-width: 1px;
 				border-style: solid;
@@ -111,8 +113,8 @@
 				white-space: nowrap;
 				width: auto;
 			}
-			:host .d2l-demo-template-actions ::content button:focus,
-			:host .d2l-demo-template-actions ::content button:hover {
+			:host .d2l-demo-template-actions ::slotted(button:focus),
+			:host .d2l-demo-template-actions ::slotted(button:hover) {
 				background-color: var(--d2l-color-gypsum);
 			}
 			@media(max-width: 600px) {
@@ -152,9 +154,9 @@
 		</div>
 		<div class="d2l-demo-template-content">
 			<div class="d2l-demo-template-actions">
-				<content select=".d2l-demo-actions"></content>
+				<slot name="d2l-demo-actions"></slot>
 			</div>
-			<content select=".d2l-demo-fixture"></content>
+			<slot name="d2l-demo-fixture"></slot>
 		</div>
 	</template>
 
@@ -239,33 +241,42 @@
 
 			_updateShadowState: function() {
 				var useShadow = this.$$('.d2l-demo-use-shadow');
-				if (Polymer.Settings.nativeShadow) {
+				// if (Polymer.Settings.nativeShadow) {
 					if (Polymer.Settings.useShadow) {
 						useShadow.textContent = 'Use Shady';
-						useShadow.setAttribute('href', this._updateQueryStringParameter(window.location.href, 'dom', ''));
+						var href = this._removeQueryStringParameter(window.location.href, 'dom');
+						href = this._updateQueryStringParameter(href, 'wc-shadydom');
+						useShadow.setAttribute('href', href);
 					} else {
 						useShadow.textContent = 'Use Shadow';
-						useShadow.setAttribute('href', this._updateQueryStringParameter(window.location.href, 'dom', 'shadow'));
+						var href = this._updateQueryStringParameter(window.location.href, 'dom', 'shadow');
+						href = this._removeQueryStringParameter(href, 'wc-shadydom');
+						useShadow.setAttribute('href', href);
+
 					}
-				} else {
-					useShadow.textContent = 'Shadow Not Supported';
-				}
+				// } else {
+				// 	useShadow.textContent = 'Shadow Not Supported';
+				// }
 			},
 
 			_updateNativeCSSPropsState: function() {
 				var useNativeCSSProps = this.$$('.d2l-demo-use-native-css-props');
 
-				if (Polymer.Settings.hasNativeCSSProperties) {
+				// if (Polymer.Settings.hasNativeCSSProperties) {
 					if (Polymer.Settings.useNativeCSSProperties) {
 						useNativeCSSProps.textContent = 'Use CSS Props Shim';
-						useNativeCSSProps.setAttribute('href', this._removeQueryStringParameter(window.location.href, 'useNativeCSSProperties'));
+						var href = this._removeQueryStringParameter(window.location.href, 'useNativeCSSProperties')
+						href = this._updateQueryStringParameter(href, 'wc-shimcssproperties')
+						useNativeCSSProps.setAttribute('href', href);
 					} else {
 						useNativeCSSProps.textContent = 'Use Native CSS Props';
-						useNativeCSSProps.setAttribute('href', this._updateQueryStringParameter(window.location.href, 'useNativeCSSProperties', 'true'));
+						var href = this._updateQueryStringParameter(window.location.href, 'useNativeCSSProperties', 'true');
+						href = this._removeQueryStringParameter(href, 'wc-shimcssproperties');
+						useNativeCSSProps.setAttribute('href', href);
 					}
-				} else {
-					useNativeCSSProps.textContent = 'Native CSS Props Not Supported';
-				}
+				// } else {
+				// 	useNativeCSSProps.textContent = 'Native CSS Props Not Supported';
+				// }
 			},
 
 			_removeQueryStringParameter: function(uri, key) {
@@ -289,7 +300,7 @@
 			_updateQueryStringParameter: function(uri, key, value) {
 				var re = new RegExp('([?|&])' + key + '=.*?(&|#|$)', 'i');
 				if (uri.match(re)) {
-					return uri.replace(re, '$1' + key + '=' + value + '$2');
+					return value ? uri.replace(re, '$1' + key + '=' + value + '$2') : uri.replace(re, '$1' + key + '$2');
 				} else {
 					var hash =  '';
 					if (uri.indexOf('#') !== -1) {
@@ -297,7 +308,7 @@
 						uri = uri.replace(/#.*/, '');
 					}
 					var separator = uri.indexOf('?') !== -1 ? '&' : '?';
-					return uri + separator + key + '=' + value + hash;
+					return value ? uri + separator + key + '=' + value + hash : uri + separator + key + hash;
 				}
 			}
 

--- a/d2l-demo-template.html
+++ b/d2l-demo-template.html
@@ -241,7 +241,7 @@
 
 			_updateShadowState: function() {
 				var useShadow = this.$$('.d2l-demo-use-shadow');
-				// if (Polymer.Settings.nativeShadow) {
+				 if (Polymer.Settings.nativeShadow || (window.ShadyCSS && window.ShadyCSS.nativeShadow)) {
 					if (Polymer.Settings.useShadow) {
 						useShadow.textContent = 'Use Shady';
 						var href = this._removeQueryStringParameter(window.location.href, 'dom');
@@ -254,15 +254,15 @@
 						useShadow.setAttribute('href', href);
 
 					}
-				// } else {
-				// 	useShadow.textContent = 'Shadow Not Supported';
-				// }
+				} else {
+					useShadow.textContent = 'Shadow Not Supported';
+				}
 			},
 
 			_updateNativeCSSPropsState: function() {
 				var useNativeCSSProps = this.$$('.d2l-demo-use-native-css-props');
 
-				// if (Polymer.Settings.hasNativeCSSProperties) {
+				if (Polymer.Settings.nativeShadow || (window.ShadyCSS && window.ShadyCSS.nativeCSS)) {
 					if (Polymer.Settings.useNativeCSSProperties) {
 						useNativeCSSProps.textContent = 'Use CSS Props Shim';
 						var href = this._removeQueryStringParameter(window.location.href, 'useNativeCSSProperties')
@@ -274,9 +274,9 @@
 						href = this._removeQueryStringParameter(href, 'wc-shimcssproperties');
 						useNativeCSSProps.setAttribute('href', href);
 					}
-				// } else {
-				// 	useNativeCSSProps.textContent = 'Native CSS Props Not Supported';
-				// }
+				} else {
+					useNativeCSSProps.textContent = 'Native CSS Props Not Supported';
+				}
 			},
 
 			_removeQueryStringParameter: function(uri, key) {

--- a/d2l-demo-template.html
+++ b/d2l-demo-template.html
@@ -314,7 +314,9 @@
 			},
 
 			_hasNativeShadowDOM: function() {
-				return Polymer.Settings.nativeShadow || document.head.createShadowRoot;
+				// attachShadow gives false positives in FF/Safari
+				// Once v1 is supported by those browsers will need to update this feature detection
+				return Polymer.Settings.nativeShadow || document.head.createShadowRoot; // || document.head.attachShadow;
 			},
 
 			_hasNativeCSSProps: function() {

--- a/d2l-demo-template.html
+++ b/d2l-demo-template.html
@@ -262,7 +262,7 @@
 			_updateNativeCSSPropsState: function() {
 				var useNativeCSSProps = this.$$('.d2l-demo-use-native-css-props');
 
-				if (Polymer.Settings.nativeShadow || (window.ShadyCSS && window.ShadyCSS.nativeCSS)) {
+				if (Polymer.Settings.hasNativeCSSProperties || (window.ShadyCSS && window.ShadyCSS.nativeCss)) {
 					if (Polymer.Settings.useNativeCSSProperties) {
 						useNativeCSSProps.textContent = 'Use CSS Props Shim';
 						var href = this._removeQueryStringParameter(window.location.href, 'useNativeCSSProperties')

--- a/d2l-demo-template.html
+++ b/d2l-demo-template.html
@@ -10,8 +10,8 @@
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
-<!-- <link rel="import" href="../d2l-typography/d2l-typography.html">
-<link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html"> -->
+<link rel="import" href="../d2l-typography/d2l-typography.html">
+<link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 
 <script>
 (function() {

--- a/d2l-demo-template.html
+++ b/d2l-demo-template.html
@@ -314,7 +314,7 @@
 
 			_hasNativeShadowDOM: function() {
 				return Polymer.Settings.nativeShadow || document.head.createShadowRoot || document.head.attachShadow;
-			}
+			},
 
 			_hasNativeCSSProps: function() {
 				return Polymer.Settings.hasNativeCSSProperties || (window.CSS && window.CSS.supports('--fake-var', 0));

--- a/d2l-demo-template.html
+++ b/d2l-demo-template.html
@@ -241,7 +241,7 @@
 
 			_updateShadowState: function() {
 				var useShadow = this.$$('.d2l-demo-use-shadow');
-				 if (_hasNativeShadowDOM()) {
+				 if (this._hasNativeShadowDOM()) {
 					if (Polymer.Settings.useShadow) {
 						useShadow.textContent = 'Use Shady';
 						var href = this._removeQueryStringParameter(window.location.href, 'dom');
@@ -262,7 +262,7 @@
 			_updateNativeCSSPropsState: function() {
 				var useNativeCSSProps = this.$$('.d2l-demo-use-native-css-props');
 
-				if (_hasNativeCSSProps()) {
+				if (this._hasNativeCSSProps()) {
 					if (Polymer.Settings.useNativeCSSProperties) {
 						useNativeCSSProps.textContent = 'Use CSS Props Shim';
 						var href = this._removeQueryStringParameter(window.location.href, 'useNativeCSSProperties')

--- a/d2l-demo-template.html
+++ b/d2l-demo-template.html
@@ -241,7 +241,7 @@
 
 			_updateShadowState: function() {
 				var useShadow = this.$$('.d2l-demo-use-shadow');
-				 if (Polymer.Settings.nativeShadow || (window.ShadyCSS && window.ShadyCSS.nativeShadow)) {
+				 if (_hasNativeShadowDOM()) {
 					if (Polymer.Settings.useShadow) {
 						useShadow.textContent = 'Use Shady';
 						var href = this._removeQueryStringParameter(window.location.href, 'dom');
@@ -262,7 +262,7 @@
 			_updateNativeCSSPropsState: function() {
 				var useNativeCSSProps = this.$$('.d2l-demo-use-native-css-props');
 
-				if (Polymer.Settings.hasNativeCSSProperties || (window.ShadyCSS && window.ShadyCSS.nativeCss)) {
+				if (_hasNativeCSSProps()) {
 					if (Polymer.Settings.useNativeCSSProperties) {
 						useNativeCSSProps.textContent = 'Use CSS Props Shim';
 						var href = this._removeQueryStringParameter(window.location.href, 'useNativeCSSProperties')
@@ -310,6 +310,14 @@
 					var separator = uri.indexOf('?') !== -1 ? '&' : '?';
 					return value ? uri + separator + key + '=' + value + hash : uri + separator + key + hash;
 				}
+			},
+
+			_hasNativeShadowDOM: function() {
+				return Polymer.Settings.nativeShadow || document.head.createShadowRoot || document.head.attachShadow;
+			}
+
+			_hasNativeCSSProps: function() {
+				return Polymer.Settings.hasNativeCSSProperties || (window.CSS && window.CSS.supports('--fake-var', 0));
 			}
 
 		});

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "description": "Polymer-based component for demo page template",
   "scripts": {
-    "postinstall": "bower install",
+    "postinstall": "polymer install --variants",
     "test": "npm run test:lint:js && npm run test:lint:wc",
     "test:lint:js": "eslint *.html",
-    "test:lint:wc": "polylint --input *.html"
+    "test:lint:wc": "polymer lint"
   },
   "repository": {
     "type": "git",
@@ -19,6 +19,6 @@
     "eslint": "^2.10.2",
     "eslint-config-brightspace": "^0.2.1",
     "eslint-plugin-html": "^1.4.0",
-    "polylint": "^2.10.0"
+    "polymer-cli": "^1.1.0"
   }
 }

--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,9 @@
+{
+    "sources": [
+        "*.html"
+    ],
+    "lint": {
+      "rules": ["polymer-2-hybrid"],
+      "ignoreWarnings": []
+    }
+}


### PR DESCRIPTION
Upgrade to Polymer 2/hybrid.

Should probably be a major version change to to the changes from `content` to `slot`.

It was a bit troublesome adding the support for the shadom/shady DOM/CSS properties as some of the Polymer.Settings that were controlling this do not seem to be available in Polymer 2.
So I had to remove the label that warns you where those things are not supported.
I guess I could have added conditional 1/2 code but was getting lazy...and trying to keep it simple.
So if you choose 'Use Shadow' and it's not supported it just refreshes the template, but 'Use Shadow' is still displayed.

One other difference which is interesting in Polymer 2 is that if you use the CSS shim option with shadow DOM then it basically breaks the page whereas in Polymer 1, it seems like if you enable shadow DOM it forces the shim to be off.