### PR TITLE
adding to the Polymer object in case it's been defined already

### DIFF
--- a/d2l-demo-template.html
+++ b/d2l-demo-template.html
@@ -2,9 +2,8 @@
 (function() {
 	'use strict';
 	// currently Polymer requries lazyRegister in order to use native CSS properties
-	window.Polymer = {
-		lazyRegister: true
-	};
+	window.Polymer = window.Polymer || {};
+	window.Polymer.lazyRegister = true;
 })();
 </script>
 


### PR DESCRIPTION
In case someone included `d2l-demo-template.html` _after_ `polymer.html`. Otherwise this overwrites the Polymer object.